### PR TITLE
Use different token to update gh-pages

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,5 +1,6 @@
 name: Update gh-pages branch on alire.ada.dev
 on:
+  push:
   schedule:
     - cron:  '0 0 * * *'
 jobs:
@@ -10,4 +11,4 @@ jobs:
     - uses: alire-project/setup-alire@dev
     - run: bash -v update-gh-pages.sh
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_PAGES_UPDATE }}

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,6 +1,5 @@
 name: Update gh-pages branch on alire.ada.dev
 on:
-  push:
   schedule:
     - cron:  '0 0 * * *'
 jobs:


### PR DESCRIPTION
According to: https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869

The action GITHUB_TOKEN cannot trigger gh-pages builds.