### PR TITLE
Fix for single dependency

### DIFF
--- a/dependency_graph.py
+++ b/dependency_graph.py
@@ -69,6 +69,8 @@ for cratefile in glob.glob("_crates/*.md"):
         crate = ydata['crate']
 
         if 'dependencies' in ydata and ydata['dependencies']:
+            if type(ydata['dependencies']) is dict:
+                ydata['dependencies'] = [ydata['dependencies']]
             for dep in ydata['dependencies']:
                 if dep['crate'] in nodes:
                     data['links'] += [{'source': crate, 'target': dep['crate'], 'value': 1}]


### PR DESCRIPTION
A single crate dependency may be a dictionary (#701). Put the dictionary into a list so it can be iterated.