### PR TITLE
Add Continuous Integration bagde to crate page

### DIFF
--- a/_data/meta.yaml
+++ b/_data/meta.yaml
@@ -1,0 +1,1 @@
+ci_site: 'https://alire-crates-ci.mosteo.com'

--- a/_layouts/crate.html
+++ b/_layouts/crate.html
@@ -60,9 +60,12 @@ No tags.
 {% assign badge_url = "https://img.shields.io/endpoint?url="| append: json_url %}
 <b>Badge: </b><img src="{{badge_url}}" title="Copy image location: {{badge_url}}"><br>
 {% assign ci_badge_url = "https://img.shields.io/endpoint?url="
-          | append: "https://alire-crates-ci.ada.dev/badges/"
+          | append: site.data.meta.ci_site | append: "/badges/"
           | append: page.crate | append: ".json" %}
-<b>Alire CI: </b><img src="{{ci_badge_url}}" title="CI badge: {{ci_badge_url}}"><br>
+<b>Alire CI: </b>
+<a href="{{ site.data.meta.ci_site}}/crates/{{page.crate}}.html" target="_blank">
+  <img src="{{ci_badge_url}}" title="CI badge: {{ci_badge_url}}"><br>
+</a>
 <hr>
 <section>
   {{ content }}

--- a/_layouts/crate.html
+++ b/_layouts/crate.html
@@ -59,6 +59,10 @@ No tags.
 {% assign json_url = "https://alire.ada.dev/badges/" | append: page.crate | append: ".json" %}
 {% assign badge_url = "https://img.shields.io/endpoint?url="| append: json_url %}
 <b>Badge: </b><img src="{{badge_url}}" title="Copy image location: {{badge_url}}"><br>
+{% assign ci_badge_url = "https://img.shields.io/endpoint?url="
+          | append: "https://alire-crates-ci.ada.dev/badges/"
+          | append: page.crate | append: ".json" %}
+<b>Alire CI: </b><img src="{{ci_badge_url}}" title="CI badge: {{ci_badge_url}}"><br>
 <hr>
 <section>
   {{ content }}

--- a/update-gh-pages.sh
+++ b/update-gh-pages.sh
@@ -71,6 +71,9 @@ rm -rf alire/
 # Generate dependency graph data
 python dependency_graph.py
 
+# Stop if not running in GHA workflow
+[ "${CI:-unset}" = "unset" ] && { echo Not running in GHA, exiting...; exit 0; }
+
 # Remove the ignore files to be able to commit crates and badges to the branch
 rm -f _crates/.gitignore _badges/.gitignore
 


### PR DESCRIPTION
I've tested it locally with [these instructions](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll).

Result:

![image](https://user-images.githubusercontent.com/264377/175291376-40759fb2-cbd8-4582-87c9-2ed5b62611b9.png)
