### PR TITLE
Online help generated from `alr help` output using `alr-help-md.sh`

### DIFF
--- a/alr-help-md.sh
+++ b/alr-help-md.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+function out2md {
+awk '
+BEGIN {
+  first=1
+}
+# Titles
+/^[A-Z][A-Za-z _-]+$/ {
+  if (first != 1) {print("</pre>")}
+  print("# " $0);
+  print("<pre>")
+  first=0;
+  next
+}
+# Paragraphs
+{
+  sub("<", "\\&lt;")
+  sub(">", "\\&gt;")
+  print
+}
+# Finish last paragraph
+END {
+  if (first != 1) {print("</pre>")}
+}'
+}
+
+topic_list=$(alr help | awk '/^ +[a-z]+/ {if ($1 !~ "alr") {print $1}}')
+
+# Make a page from each help topic
+for topic in $topic_list; do
+    alr help $topic | out2md > alr-${topic}.md
+done
+
+# Make an index from the help subcommand. Markdown links do not work inside pre
+alr help | out2md | awk '/^ +[a-z]+/ {
+  if (system("test -f alr-" $1 ".md") == 0) {
+    sub(/[a-z]+/, "<a href=\"alr-&.md\">&</a>")
+  }
+}
+{
+  print
+}' > alr-help.md
+

--- a/docs/alr-action.md
+++ b/docs/alr-action.md
@@ -1,0 +1,34 @@
+# SUMMARY
+<pre>
+   List or manually trigger action hooks
+
+</pre>
+# USAGE
+<pre>
+   alr action [options] [post_fetch|pre_build|post_build|test]
+
+</pre>
+# OPTIONS
+<pre>
+   -r (--recursive)  List or trigger actions also in dependencies
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   List or manually trigger action hooks.
+</pre>

--- a/docs/alr-aliases.md
+++ b/docs/alr-aliases.md
@@ -1,0 +1,12 @@
+# User defined command aliases
+<pre>
+   Command aliases can be defined in local or global 
+   configuration.
+
+   For example the following command:
+   "$ alr config --set --global alias.graph 'show --graph'"
+   Defines a global alias for the 'show' command with a 
+   '--graph' switch.
+
+   "$ alr graph" is equivalent to "alr show --graph"
+</pre>

--- a/docs/alr-build.md
+++ b/docs/alr-build.md
@@ -1,0 +1,36 @@
+# SUMMARY
+<pre>
+   GPRbuild current working release
+
+</pre>
+# USAGE
+<pre>
+   alr build [options] [--] [gprbuild switches and arguments]
+
+</pre>
+# OPTIONS
+<pre>
+   --release      Set root crate build mode to Release              
+   --validation   Set root crate build mode to Validation           
+   --development  Set root crate build mode to Development (default)
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Invokes gprbuild to compile all targets in the current crate.
+</pre>

--- a/docs/alr-clean.md
+++ b/docs/alr-clean.md
@@ -1,0 +1,43 @@
+# SUMMARY
+<pre>
+   GPRclean working release and manage cached releases
+
+</pre>
+# USAGE
+<pre>
+   alr clean [options] [--cache] [--temp] [--] [gprclean switches and arguments]
+
+</pre>
+# OPTIONS
+<pre>
+   --cache  Delete cache of releases       
+   --temp   Delete dangling temporary files
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   no options:
+      gprclean -r will be called to clean up the build environment.
+
+   --cache:
+      All downloaded dependencies will be deleted.
+
+   --temp:
+      All alr-???.tmp files in the subtree will be deleted. These files may 
+   remain when alr is interrupted via Ctrl-C or other forceful means.
+</pre>

--- a/docs/alr-config.md
+++ b/docs/alr-config.md
@@ -1,0 +1,116 @@
+# SUMMARY
+<pre>
+   List, Get, Set or Unset configuration options
+
+</pre>
+# USAGE
+<pre>
+   alr config [options] [--list] [--show-origin] [key_regex] | --get &lt;key&gt; | --set <key> <value> | --unset <key>
+
+</pre>
+# OPTIONS
+<pre>
+   --list          List configuration options                                 
+   --show-origin   Show origin of configuration values in --list              
+   --get           Print value of a configuration option                      
+   --set           Set a configuration option                                 
+   --unset         Unset a configuration option                               
+   --global        Set and Unset global configuration instead of the local one
+   --builtins-doc  Print Markdown list of built-in configuration options      
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Provides a command line interface to the Alire configuration option files.
+
+   Option names (keys) can use lowercase and uppercase alphanumeric characters
+   from the Latin alphabet. Underscores and dashes can also be used except as
+   first or last character. Dot '.' is used to specify sub-categories, e.g.
+   'user.name' or 'user.email'.
+
+   Option values can be integers, float, Boolean (true or false) or strings. The
+   type detection is automatic, e.g. 10 is integer, 10.1 is float, true is
+   Boolean. You can force a value to be set a string by using double-quotes, 
+   e.g.
+   "10.1" or "true". Extra type checking is used for built-in options (see 
+   below).
+
+   Built-in configuration options:
+
+   - index.auto_community [Boolean]
+   When unset (default) or true, the community index will be added automatically
+   when required if no other index is configured.
+
+   - user.name [String]
+   User full name. Used for the authors and maintainers field of a new crate.
+
+   - user.email [Email address]
+   User email address. Used for the authors and maintainers field of a new 
+   crate.
+
+   - user.github_login [GitHub login]
+   User GitHub login/username. Used to for the maintainers-logins field of a new
+   crate.
+
+   - editor.cmd [String]
+   Editor command and arguments for editing crate code (alr edit). The 
+   executables and arguments are separated by a single space character. The 
+   token ${GPR_FILE} is replaced by a path to the project file to open.
+
+   - msys2.do_not_install [Boolean]
+   If true, Alire will not try to automatically install msys2 system package 
+   manager. (Windows only)
+
+   - msys2.install_dir [Absolute path]
+   Directory where Alire will detect and/or install msys2 system package 
+   manager. (Windows only)
+
+   - msys2.installer [String]
+   Filename of the executable msys2 installer, e.g. 'msys2-x86_64-20220319.exe'.
+   (Windows only)
+
+   - msys2.installer_url [String]
+   URL of the executable msys2 installer, e.g. 'https://github.com/msys2/msys2-
+   installer/releases/download/2022-03-19/msys2-x86_64-20220319.exe'. (Windows 
+   only)
+
+   - update-manually-only [Boolean]
+   If true, Alire will not attempt to update dependencies even after the 
+   manifest is manually edited, or when no valid solution has been ever 
+   computed. All updates have to be manually requested through `alr update`
+
+   - distribution.disable_detection [Boolean]
+   If true, Alire will report an unknown distribution and will not attempt to 
+   use the system package manager.
+
+   - solver.autonarrow [Boolean]
+   If true, `alr with` will replace 'any' dependencies with the appropriate 
+   caret/tilde dependency.
+
+   - warning.caret [Boolean]
+   If true, Alire will warn about the use of caret (^) for pre-1 dependencies.
+
+   - warning.old_index [Boolean]
+   When unset (default) or true, a warning will be emitted when using a 
+   compatible index with a lower version than the newest known.
+
+   - toolchain.assistant [Boolean]
+   If true, and assistant to select the default toolchain will run when first 
+   needed.
+
+</pre>

--- a/docs/alr-dev.md
+++ b/docs/alr-dev.md
@@ -1,0 +1,38 @@
+# SUMMARY
+<pre>
+   Developer helpers
+
+</pre>
+# USAGE
+<pre>
+   alr dev [options] 
+
+</pre>
+# OPTIONS
+<pre>
+   --custom  Execute current custom code 
+   --filter  Used by scope filtering test
+   --raise   Raise an exception          
+   --test    Run self-tests              
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Internal command for development help. Options and features are not stable 
+   and may change without warning.
+</pre>

--- a/docs/alr-edit.md
+++ b/docs/alr-edit.md
@@ -1,0 +1,34 @@
+# SUMMARY
+<pre>
+   Start GNATstudio with Alire build environment setup
+
+</pre>
+# USAGE
+<pre>
+   alr edit [options] 
+
+</pre>
+# OPTIONS
+<pre>
+   --project=ARG  Select the project file to open if the crate provides multiple project files, ignored otherwise
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Start GNATstudio with Alire build environment setup.
+</pre>

--- a/docs/alr-exec.md
+++ b/docs/alr-exec.md
@@ -1,0 +1,47 @@
+# SUMMARY
+<pre>
+   Run the given command in the alire project context
+
+</pre>
+# USAGE
+<pre>
+   alr exec [options] [-P?] [--] &lt;executable/script&gt; [<switches and arguments>]
+
+</pre>
+# OPTIONS
+<pre>
+   -P[ARG]  Add "-P &lt;PROJECT_FILE&gt;" to the command switches
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Alr sets up the environment variables (GPR_PROJECT_PATH, 
+   PATH, etc.) and then spawns the given command.
+
+   This can be used to run tools or scripts on Alire projects.
+
+   The "-P" switch can be used to ask Alire to insert a 
+   "-P &lt;PROJECT_FILE&gt;" switch to the command arguments.
+   "-P" takes an optional position argument to specify where
+   to insert the extra switch. "-P1" means first position, 
+   "-P2" second position, etc. "-P-1" means last position, 
+   "-P-2" penultimate position, etc. "-P" equals "-P1".
+   For example "alr exec -P2 -- python3 main.py arg1" will
+   run the following command:
+   ["python3", "main.py", "-P", "crate.gpr", "arg1"]
+</pre>

--- a/docs/alr-get.md
+++ b/docs/alr-get.md
@@ -1,0 +1,46 @@
+# SUMMARY
+<pre>
+   Fetches a crate release
+
+</pre>
+# USAGE
+<pre>
+   alr get [options] &lt;crate&gt;[allowed versions]
+
+</pre>
+# OPTIONS
+<pre>
+   -b (--build)  Build after download                               
+   --dirname     Display deployment folder                          
+   -o (--only)   Retrieve requested crate only, without dependencies
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Retrieve a crate, in the case of regular ones, or install a system package 
+   provided by the platform. A regular crate is deployed under an immediate 
+   folder with naming 'name_version_hash'.
+
+   Version selection syntax (global policy applies within the allowed version 
+   subsets):
+
+   crate        	Newest/oldest version
+   crate=version	Exact version
+   crate^version	Major-compatible version
+   crate~version	Minor-compatible version
+</pre>

--- a/docs/alr-gnatcov.md
+++ b/docs/alr-gnatcov.md
@@ -1,0 +1,1 @@
+'gnatcov' is an alias for: 'alr exec -P2 -- gnatcov'

--- a/docs/alr-gnatprove.md
+++ b/docs/alr-gnatprove.md
@@ -1,0 +1,1 @@
+'gnatprove' is an alias for: 'alr exec -P1 -- gnatprove'

--- a/docs/alr-help.md
+++ b/docs/alr-help.md
@@ -1,0 +1,70 @@
+# USAGE
+<pre>
+   alr help [&lt;command&gt;|<topic>]
+
+</pre>
+# ARGUMENTS
+<pre>
+   &lt;command&gt;  Command for which to show a description
+   &lt;topic&gt;    Topic for which to show a description  
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# COMMANDS
+<pre>
+   General  
+   <a href="alr-help.md">help</a>          Shows help on the given command/topic                                  
+   <a href="alr-config.md">config</a>        List, Get, Set or Unset configuration options                          
+   <a href="alr-printenv.md">printenv</a>      Print the build environment variables                                  
+   <a href="alr-toolchain.md">toolchain</a>     Manage Alire-provided toolchains                                       
+   <a href="alr-version.md">version</a>       Shows detailed version, configuration, and environment information     
+ 
+   Index    
+   <a href="alr-get.md">get</a>           Fetches a crate release                                                
+   <a href="alr-index.md">index</a>         Manage indexes used by current configuration                           
+   <a href="alr-init.md">init</a>          Creates a new working release with alire metadata, or generate metadata
+   <a href="alr-pin.md">pin</a>           Pin dependencies to exact versions                                     
+   <a href="alr-search.md">search</a>        Search a string in release names and properties                        
+   <a href="alr-show.md">show</a>          See information about a release                                        
+   <a href="alr-update.md">update</a>        Updates alire catalog and working release dependencies                 
+   <a href="alr-with.md">with</a>          Manage release dependencies                                            
+ 
+   Build    
+   <a href="alr-action.md">action</a>        List or manually trigger action hooks                                  
+   <a href="alr-build.md">build</a>         GPRbuild current working release                                       
+   <a href="alr-clean.md">clean</a>         GPRclean working release and manage cached releases                    
+   <a href="alr-dev.md">dev</a>           Developer helpers                                                      
+   <a href="alr-edit.md">edit</a>          Start GNATstudio with Alire build environment setup                    
+   <a href="alr-run.md">run</a>           Launch an executable built by the release                              
+   <a href="alr-test.md">test</a>          Tests the compilation of all or some releases                          
+   <a href="alr-exec.md">exec</a>          Run the given command in the alire project context                     
+ 
+   Publish  
+   <a href="alr-publish.md">publish</a>       Help with the publication of a new release                             
+
+</pre>
+# TOPICS
+<pre>
+   <a href="alr-aliases.md">aliases</a>         User defined command aliases          
+   <a href="alr-identifiers.md">identifiers</a>     Naming rules for crate and index names
+   <a href="alr-toolchains.md">toolchains</a>      Configuration and use of toolchains   
+</pre>
+# ALIASES
+<pre>
+   <a href="alr-gnatcov.md">gnatcov</a>       exec -P2 -- gnatcov  
+   <a href="alr-gnatprove.md">gnatprove</a>     exec -P1 -- gnatprove
+</pre>

--- a/docs/alr-identifiers.md
+++ b/docs/alr-identifiers.md
@@ -1,0 +1,8 @@
+# Naming rules for crate and index names
+<pre>
+   Identifiers for crates and indexes must use lowercase alphanumeric characters
+   from the latin alphabet. Underscores can also be used except as the first 
+   character.
+
+   Length must be of 3 to 64 characters.
+</pre>

--- a/docs/alr-index.md
+++ b/docs/alr-index.md
@@ -1,0 +1,45 @@
+# SUMMARY
+<pre>
+   Manage indexes used by current configuration
+
+</pre>
+# USAGE
+<pre>
+   alr index [options] --add &lt;url&gt; --name <name> [--before <name>] | --del <name> | [--list] | --update-all | --check
+
+</pre>
+# OPTIONS
+<pre>
+   --add=URL          Add an index                                         
+   --before=NAME      Priority order (defaults to last)                    
+   --check            Check index contents for unknown configuration values
+   --del=NAME         Remove an index                                      
+   --list             List configured indexes (default)                    
+   --name=NAME        User given name for the index                        
+   --update-all       Update configured indexes                            
+   --reset-community  Add the community index, or reset any local changes  
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Add, remove, list and update indexes used by the current alr configuration.
+
+   Updating applies only to repository-stored indexes, in which case a pull 
+   operation will be performed on them. An index initially set up with a 
+   specific commit will not be updated.
+</pre>

--- a/docs/alr-init.md
+++ b/docs/alr-init.md
@@ -1,0 +1,41 @@
+# SUMMARY
+<pre>
+   Creates a new working release with alire metadata, or generate metadata
+
+</pre>
+# USAGE
+<pre>
+   alr init [options] {--bin|--lib} &lt;crate name&gt;
+
+</pre>
+# OPTIONS
+<pre>
+   --bin       New project is an executable            
+   --lib       New project is a library                
+   --in-place  Create alr files in current folder      
+   --no-skel   Do not generate non-alire skeleton files
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Initializes a new crate containing a ready-to-build GNAT project. The crate 
+   is created as a child of the current directory, containing minimal sources 
+   for an executable or library, as specified.
+
+   --in-place is intended to be used inside the crate directory.
+</pre>

--- a/docs/alr-pin.md
+++ b/docs/alr-pin.md
@@ -1,0 +1,51 @@
+# SUMMARY
+<pre>
+   Pin dependencies to exact versions
+
+</pre>
+# USAGE
+<pre>
+   alr pin [options] [[crate[=&lt;version&gt;]] | crate --use=<path> [--commit=REF] [--branch=NAME] | --all]
+
+</pre>
+# OPTIONS
+<pre>
+   --all           Pin the complete solution                            
+   --unpin         Unpin a release                                      
+   --branch=NAME   Branch to be tracked in repository                   
+   --commit=REF    Reference to be retrieved from repository            
+   --use=PATH|URL  Use a directory or repository to fulfill a dependency
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Pin releases to a particular version. By default, the current solution 
+   version is used. A pinned release is not affected by automatic updates.
+
+   Without arguments, show existing pins.
+
+   Use --all to pin the whole current solution.
+
+   Specify a single crate to modify its pin.
+
+   Use the --use &lt;PATH|URL&gt; switch to use the target to fulfill a dependency 
+   locally instead of looking for indexed releases. An optional reference can be
+   specified with --commit; the pin will be frozen at the commit currently 
+   matching the reference.  Alternatively, a branch to track can be specified 
+   with --branch. Use `alr update` to refresh the tracking pin contents.
+</pre>

--- a/docs/alr-printenv.md
+++ b/docs/alr-printenv.md
@@ -1,0 +1,42 @@
+# SUMMARY
+<pre>
+   Print the build environment variables
+
+</pre>
+# USAGE
+<pre>
+   alr printenv [options] 
+
+</pre>
+# OPTIONS
+<pre>
+   --details     Print details about the environment variables and their origin
+   --unix        Use a UNIX shell format for the export (default)              
+   --powershell  Use a Windows PowerShell format for the export                
+   --wincmd      Use a Windows CMD shell format for the export                 
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Print the environment variables used to build the crate. This command can be 
+   used to setup a build environment, for instance before starting an IDE.
+
+   Examples:
+     - eval $(alr printenv --unix)
+     - alr printenv --powershell | Invoke-Expression
+</pre>

--- a/docs/alr-publish.md
+++ b/docs/alr-publish.md
@@ -1,0 +1,53 @@
+# SUMMARY
+<pre>
+   Help with the publication of a new release
+
+</pre>
+# USAGE
+<pre>
+   alr publish [options] [--skip-build] [--tar] [--manifest &lt;file&gt;] [<URL> [commit]]]
+
+</pre>
+# OPTIONS
+<pre>
+   --manifest=ARG   Selects a manifest file other than ./alire.toml                                 
+   --tar            Start the publishing assistant to create a source archive from a local directory
+   --trusted-sites  Print a list of trusted git repository sites                                    
+   --skip-build     Skip the build check step                                                       
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Checks a release and generates an index manifest
+
+   See full details at
+
+    https://github.com/alire-project/alire/blob/master/doc/publishing.md
+
+   URL is an optional path to a remote source archive, or a local or remote git 
+   repository.
+
+   For the common use case of a github-hosted repository, issue `alr publish` 
+   after committing and pushing the new release version.
+
+   Use --tar to create a source archive ready to be uploaded.
+
+   Use --manifest to use metadata in a non-default file.
+
+   See the above link for help with other scenarios.
+</pre>

--- a/docs/alr-run.md
+++ b/docs/alr-run.md
@@ -1,0 +1,40 @@
+# SUMMARY
+<pre>
+   Launch an executable built by the release
+
+</pre>
+# USAGE
+<pre>
+   alr run [options] [executable] [--args=ARGS] [--skip-build] | [--list]
+
+</pre>
+# OPTIONS
+<pre>
+   -a (--args=ARGS)   Arguments to pass through (quote them if more than one)
+   --list             List executables produced by current release           
+   -s (--skip-build)  Skip building step                                     
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Compiles the crate (unless --skip-build is specified) and then executes the 
+   default or given resulting executable. 
+
+   With --list, a list of declared executables is produced instead of invoking 
+   the compiler, and its location (if already built) is given.
+</pre>

--- a/docs/alr-search.md
+++ b/docs/alr-search.md
@@ -1,0 +1,57 @@
+# SUMMARY
+<pre>
+   Search a string in release names and properties
+
+</pre>
+# USAGE
+<pre>
+   alr search [options] &lt;search term&gt; | [--crates] [--full] --list
+
+</pre>
+# OPTIONS
+<pre>
+   --crates           Restrict search and output to crate names and descriptions
+   --external-detect  Detect externally-provided releases (implies --external)  
+   --full             Show all versions of a crate (newest only otherwise)      
+   --list             List all available releases                               
+   --external         Include externally-provided releases in search            
+   --property=TEXT    Search TEXT in property values                            
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Searches the given substring in crate names (or properties with --property), 
+   and shows the most recent release of matching crates (unless --full is 
+   specified).
+
+   Use --crates to get a simple list of only crate names and  descriptions. 
+   Otherwise, besides version, description and release notes, a status column 
+   with the following status flags is provided:
+
+   E: the release is externally provided.
+   S: the release is available through a system package.
+   U: the release is not available in the current platform.
+   X: the release has dependencies that cannot be resolved.
+
+   The reasons for unavailability (U) can be ascertained with 'alr show 
+   &lt;crate&gt;=<version>'.
+
+   Unresolvable releases (X) should not happen in platforms with assigned 
+   maintainers. Common reasons are missing system dependencies that have been 
+   phased out by the platform without being updated yet in the community index.
+</pre>

--- a/docs/alr-show.md
+++ b/docs/alr-show.md
@@ -1,0 +1,55 @@
+# SUMMARY
+<pre>
+   See information about a release
+
+</pre>
+# USAGE
+<pre>
+   alr show [options] [&lt;crate&gt;[allowed versions]] [--system] [--external[-detect] | --graph | --jekyll | --solve | --tree
+
+</pre>
+# OPTIONS
+<pre>
+   --detail           Show additional details about dependencies      
+   --external-detect  Add detected externals to available releases    
+   --external         Show info about external definitions for a crate
+   --graph            Print ASCII graph of dependencies               
+   --system           Show info relevant to current environment       
+   --solve            Solve dependencies and report                   
+   --tree             Show complete dependency tree                   
+   --jekyll           Enable Jekyll output format                     
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Shows information found in the loaded indexes about a specific release (see 
+   below to narrow the searched milestones). By default, only direct 
+   dependencies are reported. With --solve, a full solution is resolved and 
+   reported in list and graph form.
+
+   With --external, the external definitions for a crate are shown, instead of 
+   information about a particular release
+
+   Version selection syntax (global policy applies within the allowed version 
+   subsets):
+
+   crate        	Newest/oldest version
+   crate=version	Exact version
+   crate^version	Major-compatible version
+   crate~version	Minor-compatible version
+</pre>

--- a/docs/alr-test.md
+++ b/docs/alr-test.md
@@ -1,0 +1,53 @@
+# SUMMARY
+<pre>
+   Tests the compilation of all or some releases
+
+</pre>
+# USAGE
+<pre>
+   alr test [options] [crate[versions]]...
+
+</pre>
+# OPTIONS
+<pre>
+   --continue        Skip testing of releases already in folder                     
+   --docker[=IMAGE]  Test releases within docker IMAGE (or alire/gnat:debian-stable)
+   --full            Test all indexed crates                                        
+   --newest          Test only the newest release in crates                         
+   --redo            Retest releases already in folder (implies --continue)         
+   --search          Interpret arguments as substrings instead of exact crate names 
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Tests the retrievability and buildability of all or specific releases. Unless
+   --continue or --redo is given, the command expects to be run in an empty 
+   folder.
+
+   After completion, a report in text, markup and junit format will be available
+   in the current directory. A complete log of each release building process 
+   will be available in respective &lt;release&gt;/alire/alr_test.log files.
+
+   Version selection syntax (global policy applies within the allowed version 
+   subsets):
+
+   crate        	Newest/oldest version
+   crate=version	Exact version
+   crate^version	Major-compatible version
+   crate~version	Minor-compatible version
+</pre>

--- a/docs/alr-toolchain.md
+++ b/docs/alr-toolchain.md
@@ -1,0 +1,54 @@
+# SUMMARY
+<pre>
+   Manage Alire-provided toolchains
+
+</pre>
+# USAGE
+<pre>
+   alr toolchain [options] [-u|--uninstall] [-i|--install crate[version set]] | --select [--local] [releases] [--disable-assistant]
+
+</pre>
+# OPTIONS
+<pre>
+   --disable-assistant  Disable autorun of selection assistant          
+   -i (--install)       Install one or more toolchain component         
+   --install-dir=ARG    Toolchain component(s) installation directory   
+   --local              Store toolchain configuration in local workspace
+   --select             Run the toolchain selection assistant           
+   -u (--uninstall)     Uninstall one or more toolchain component       
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Download toolchain elements, like GNAT and gprbuild, in the shared cache of 
+   the active configuration.
+
+   Run it without arguments to get a list of downloaded tools.
+
+   Use --select without arguments to run the assistant to select the default 
+   toolchain for this configuration. Adding --local will instead make the 
+   selection apply only to the workspace (overriding a possible configuration-
+   wide selection). Giving one or more releases argument will skip the assistant
+   and set the release as the default.
+
+   Specify --install/--uninstall and one or more crates name with optional 
+   version set to make available or remove a tool.
+
+   Run `alr help toolchains` for further information about toolchain management 
+   and use.
+</pre>

--- a/docs/alr-toolchains.md
+++ b/docs/alr-toolchains.md
@@ -1,0 +1,17 @@
+# Configuration and use of toolchains
+<pre>
+   Alire indexes binary releases of GNAT and gprbuild. The compilers are indexed
+   with their target name, e.g., gnat_native or gnat_riscv_elf. 
+
+   Use alr toolchain --help to obtain information about toolchain management. 
+   Alire can be configured to rely on a toolchain installed by the user in the 
+   environment, or to use one of the indexed toolchains whenever possible.
+
+   Some crates may override the default toolchain by specifying dependencies on 
+   particular compiler crates, for example to use a cross-compiler. In this 
+   situation, a compiler already available (selected as default or already 
+   installed) will take precedence over a compiler available in the catalog. 
+
+   See also https://alire.ada.dev/docs/#toolchains for additional details about 
+   compiler dependencies and toolchain interactions.
+</pre>

--- a/docs/alr-update.md
+++ b/docs/alr-update.md
@@ -1,0 +1,40 @@
+# SUMMARY
+<pre>
+   Updates alire catalog and working release dependencies
+
+</pre>
+# USAGE
+<pre>
+   alr update [options] [crate]...
+
+</pre>
+# OPTIONS
+<pre>
+   --online  Fetch index updates before attempting crate updates
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Resolves unpinned dependencies using available indexes.
+
+   Invoked without arguments will consider all unpinned crates for updating.
+
+   One or more crates can be given as argument, in which case only these crates 
+   will be candidates for updating. Requesting the update of a pinned crate is 
+   not allowed.
+</pre>

--- a/docs/alr-version.md
+++ b/docs/alr-version.md
@@ -1,0 +1,30 @@
+# SUMMARY
+<pre>
+   Shows detailed version, configuration, and environment information
+
+</pre>
+# USAGE
+<pre>
+   alr version [options] 
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Shows assorted metadata about the alr executable, and about the crate or 
+   sandbox found in the current directory, if any.
+</pre>

--- a/docs/alr-with.md
+++ b/docs/alr-with.md
@@ -1,0 +1,77 @@
+# SUMMARY
+<pre>
+   Manage release dependencies
+
+</pre>
+# USAGE
+<pre>
+   alr with [options] [{ [--del] &lt;crate&gt;[versions]... | --from <gpr_file>... | <crate>[versions] --use <path> [--commit REF] [--branch NAME]} ] | --solve | --tree | --versions
+
+</pre>
+# OPTIONS
+<pre>
+   --del           Remove given dependencies                        
+   --from          Use dependencies declared within GPR project file
+   --graph         Show ASCII graph of dependencies                 
+   --branch=NAME   Branch to track in repository                    
+   --commit=REF    Commit to retrieve from repository               
+   --use=PATH|URL  Add a dependency pinned to some external source  
+   --solve         Show complete solution to dependencies           
+   --tree          Show complete dependency tree                    
+   --versions      Show version status of dependencies              
+
+</pre>
+# GLOBAL OPTIONS
+<pre>
+   -c (--config=ARG)       Override configuration folder location                              
+   -f (--force)            Keep going after a recoverable troublesome situation                
+   -h (--help)             Display general or command-specific help                            
+   -n (--non-interactive)  Assume default answers for all user prompts                         
+   --no-color              Disables colors in output                                           
+   --no-tty                Disables control characters in output                               
+   --prefer-oldest         Prefer oldest versions instead of newest when resolving dependencies
+   --version               Displays version and exits                                          
+   -q                      Limit output to errors                                              
+   -v                      Be more verbose (use twice for extra detail)                        
+   -d (--debug[])          Enable debug-specific log messages                                  
+
+</pre>
+# DESCRIPTION
+<pre>
+   Inspect and manage dependencies.
+
+   * Inspecting dependencies:
+   Run without arguments prints current dependencies. Use --solve to print the 
+   solution in use for these dependencies.
+
+   * Adding dependencies from the command line:
+   Dependencies are added by giving their name, and removed by using the --del 
+   flag. Dependencies cannot be simultaneously added and removed in a single 
+   invocation.
+
+   * Adding dependencies pinned to external sources:
+   When a single crate name is accompanied by an --use PATH|URL argument, the 
+   crate is always fulfilled for any required version by the sources found at 
+   the given target. An optional reference can be specified with --commit; the 
+   pin will be frozen at the commit currently matching the reference. 
+   Alternatively, a branch to track can be specified with --branch. Use `alr 
+   update` to refresh the tracking pin contents.
+
+   * Adding dependencies from a GPR file:
+   The project file given with --from will be scanned looking for comments that 
+   contain the sequence 'alr with'.  These will be processed individually as if 
+   they had been given in the command line, starting with no dependencies. That 
+   is, only dependencies given in the GPR file will be preserved.
+
+   Example of GPR file contents:
+
+   with "libhello"; -- alr with libhello
+
+   Version selection syntax (global policy applies within the allowed version 
+   subsets):
+
+   crate        	Newest/oldest version
+   crate=version	Exact version
+   crate^version	Major-compatible version
+   crate~version	Minor-compatible version
+</pre>


### PR DESCRIPTION
This allows this built-in documentation to be discovered by search engines and providing links to topics for sharing in Internet.