### PR TITLE
Make TOC sidebar sticky and scrollable

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,11 +9,17 @@ layout: default
 .doc_toc {
   float: left;
   width: 15em;
+  position: sticky;
+  top: 1em;
+  bottom: 1em;
+  overflow-y: scroll;
+  height: 100vh;
 }
 
 .doc_content {
   float: left;
   width: calc(100% - 15em);
+  padding-left: 1em;
 }
 
 /* Clear floats after the columns */


### PR DESCRIPTION
For a better user experience when reading the docs, the sidebar now stays on the screen even when scrolling past it. As it is bigger than the viewport height, it is also made scrollable.