### PR TITLE
fix: toc bar size

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,10 +40,10 @@ of next to each other */
 @media screen and (min-width: 60em) {
   .doc_toc {
     position: sticky;
-    top: 1em;
-    bottom: 1em;
+    top: 0;
     overflow-y: scroll;
     height: 100vh;
+    padding: 1em 0;
   }
   .doc_content {
     padding-left: 1em;


### PR DESCRIPTION
The bottom of the TOC bar was hidden by sticking it at 1em from the top. The padding is now applied on the element, and the bar is now completely visible and scrollable.